### PR TITLE
Fix average time calculation and dataset header

### DIFF
--- a/task1_divide_best_first_search.py
+++ b/task1_divide_best_first_search.py
@@ -59,6 +59,15 @@ def main():
     rtree2.fit(data_points2)
     results, average_time, total_time = best_first_divide_search(rtree1, rtree2, query_points)
     # Write results to file
-    write_file(results_dir, results, average_time, total_time, "divide_best_first_search", results_dir.name)
+    # Use the dataset name for the summary header rather than the results file
+    # name to keep output consistent with other scripts.
+    write_file(
+        results_dir,
+        results,
+        average_time,
+        total_time,
+        "divide_best_first_search",
+        dataset_dir.name,
+    )
 if __name__ == "__main__":
     main()

--- a/utils.py
+++ b/utils.py
@@ -38,9 +38,17 @@ def write_summary(results: dict[dict], filename: Path, dataset_name: str) -> Non
 def write_file(filename, results, average_time, total_time, name, dataset_name):
     #save the results to a file
     with open(filename, 'w') as result_file:
-        result_file.write(f"Summary of Nearest Neighbor Search Results for {dataset_name}\n")
-        result_file.write(f"Time taken for nearest neighbor {name} search: {total_time:.4f} seconds\n")
-        result_file.write(f"Average time per query: {average_time / len(results):.6f} seconds\n")
+        result_file.write(
+            f"Summary of Nearest Neighbor Search Results for {dataset_name}\n"
+        )
+        result_file.write(
+            f"Time taken for nearest neighbor {name} search: {total_time:.4f} seconds\n"
+        )
+        # average_time already represents the per-query time, so do not divide
+        # by the number of results again.
+        result_file.write(
+            f"Average time per query: {average_time:.6f} seconds\n"
+        )
         for result in results:
             result = f"id={result[0]}, x={result[1]}, y={result[2]} for query {result[3]}"
             result_file.write(result + '\n')


### PR DESCRIPTION
## Summary
- correct average time reporting in result writer
- use dataset name in divide search result file

## Testing
- `python -m py_compile *.py`
- `python task1_sequintial_search.py --dataset-dir Task1_Datasets/parking_dataset_sample.txt --query-dir Task1_Datasets/query_points.txt --results-dir /tmp/results.txt`

------
https://chatgpt.com/codex/tasks/task_e_683fcded53608322a18a77f71d027c82